### PR TITLE
FIX psr-4 in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "autoload": {
-        "psr-4": {"iDoklad-v2\\": "src/"}
+        "psr-4": {"malcanek\\iDoklad\\": "src/"}
     },
     "require": {
         "php": ">=5.3.0"


### PR DESCRIPTION
Po nainstalování do nette projektu přes composer se knihovna nenačítá skrze autoloader. Opravil jsem psr-4.