### PR TITLE
decode refreshed credentials as array for error check

### DIFF
--- a/src/auth/iDokladAuth.php
+++ b/src/auth/iDokladAuth.php
@@ -121,7 +121,7 @@ class iDokladAuth {
             $params = array('grant_type' => 'refresh_token', 'client_id' => $this->clientId, 'client_secret' => $this->clientSecret, 'scope' => 'idoklad_api%20offline_access', 'refresh_token' => $this->credentials->getRefreshToken(), 'redirect_uri' => $this->redirectUri);
             $json = $this->curl($params);
             if(!empty($json)){
-                $ret = json_decode($json);
+                $ret = json_decode($json, true);
                 if(!isset($ret['error'])){
                     $this->credentials = new iDokladCredentials($json, true);
                     $this->credentials->addLastValidation(date('Y-m-d H:i:s'));


### PR DESCRIPTION
There is an error check, but on array, but json_encode returns object.