### PR TITLE
fix CCF reauth

### DIFF
--- a/src/auth/iDokladCredentials.php
+++ b/src/auth/iDokladCredentials.php
@@ -8,6 +8,8 @@
 
 namespace malcanek\iDoklad\auth;
 
+use malcanek\iDoklad\iDokladException;
+
 class iDokladCredentials {
     
     /**


### PR DESCRIPTION
This PR fixes the problem with an expiration of access_token for the CCF. 

As far I understand the iDoklad API, the CCF does not support the refresh_token. So after the expiration of access_token the checkAuthToken() method calls only oauth2Refresh() but with null value for the refresh_token. Is it mistake? Have I understood it correctly?


I also allowed myself to fix typos, magic constants and problem with the json decoding (also fixed in https://github.com/malcanek/iDoklad-v2/pull/8).