### PR TITLE
Allow full request error description in case of HTTP RC 400

### DIFF
--- a/src/request/iDokladResponse.php
+++ b/src/request/iDokladResponse.php
@@ -174,7 +174,6 @@ class iDokladResponse {
      */
     private function parseJSON($json){
         if($this->getCode() == 400){
-            $this->data = $json;
             throw new iDokladException('Request error: '.$json);
         }
         if(empty($json)){

--- a/src/request/iDokladResponse.php
+++ b/src/request/iDokladResponse.php
@@ -84,7 +84,7 @@ class iDokladResponse {
             throw new iDokladException($this->getCodeText(), $code);
         }
         
-        if($code < 300){
+        if($code < 300 || $code == 400){
             $parsed = $this->parseJSON(trim(substr($rawOutput, $headerSize)));
             $this->data = empty($parsed['Data']) ? $parsed : $parsed['Data'];
             $this->links = empty($parsed['Links']) ? null : $parsed['Links'];


### PR DESCRIPTION
As we haven't any possibility to get details about wrong input params in current code, please consider to allow RC 400 to throw Exception with details. Seems to be the case before, but now is parsing restricted to RC below 300.

Thank you.