### PR TITLE
Uprava iDokladException.php

### DIFF
--- a/src/iDokladException.php
+++ b/src/iDokladException.php
@@ -12,7 +12,7 @@ use Exception;
 class iDokladException extends Exception {
     private $payload;
 
-    public function __construct($message = "", $code = 0, $payload) {
+    public function __construct($message = "", $code = 0, $payload = null) {
         $this->payload = $payload;
         parent::__construct($message, $code);
     }


### PR DESCRIPTION
Pridani vychozi hodnoty 3. prametru vyjimky iDokladException. Na php 7.4 haze chybu:

ArgumentCountError

Too few arguments to function malcanek\iDoklad\iDokladException::__construct(), 1 passed in /vendor/malcanek/idoklad-v2/src/iDoklad.php on line 147 and exactly 3 expected